### PR TITLE
feat: display the commit hash and other configurable info in a footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,54 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Environment Variables
+
+The application uses environment variables for configuration. Create the following files for different environments:
+
+- `.env.development.local` - for local development
+- `.env.production.local` - for production builds
+- `.env.test.local` - for testing
+
+### Required Variables
+
+```bash
+AIRTABLE_API_KEY=your_airtable_api_key
+AIRTABLE_BASE_ID=your_airtable_base_id
+```
+
+### Optional Variables
+
+#### Footer Configuration
+
+You can customize the footer content that appears on the right side next to the version information:
+
+```bash
+# Footer right content (HTML supported)
+NEXT_PUBLIC_FOOTER_RIGHT_HTML='<a href="https://github.com/yourusername/your-repo" target="_blank" rel="noopener noreferrer" class="text-gray-500 hover:text-gray-700 underline">GitHub</a> | <a href="mailto:support@yourdomain.com" class="text-gray-500 hover:text-gray-700 underline">Report Bug</a>'
+```
+
+**Examples:**
+- Simple link: `NEXT_PUBLIC_FOOTER_RIGHT_HTML='<a href="https://github.com/user/repo" target="_blank">GitHub</a>'`
+- Multiple links: `NEXT_PUBLIC_FOOTER_RIGHT_HTML='<a href="https://github.com/user/repo">GitHub</a> | <a href="mailto:bugs@example.com">Support</a>'`
+- Plain text: `NEXT_PUBLIC_FOOTER_RIGHT_HTML='© 2025 Your Organization'`
+
+If not set, only the version information will be displayed in the footer.
+
+### Setting Environment Variables on Vercel
+
+When deploying to Vercel, set your environment variables in the Vercel dashboard:
+
+1. Go to your project in the [Vercel Dashboard](https://vercel.com/dashboard)
+2. Navigate to **Settings** → **Environment Variables**
+3. Add the required variables:
+   - `AIRTABLE_API_KEY` (keep this secret)
+   - `AIRTABLE_BASE_ID`
+   - `NEXT_PUBLIC_FOOTER_RIGHT_HTML` (optional)
+4. Set the appropriate environment (Production, Preview, Development)
+5. Deploy your application
+
+**Note:** Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser, while others remain server-side only.
+
 ## Development
 
 Lint and run prettier locally. Note that `prettier` is configured so that it

--- a/app/footer.tsx
+++ b/app/footer.tsx
@@ -7,13 +7,10 @@ export default function Footer() {
 
   return (
     <footer className="sm:fixed bottom-0 left-0 right-0 bg-gray-50 border-t border-gray-200 py-2 z-20">
-      <div className="px-3 flex justify-between items-center">
-        <span className="text-xs text-gray-500">Version: {commitHash}</span>
+      <div className="px-3 flex justify-between items-center text-xs text-gray-500">
+        Version: {commitHash}
         {footerRightContent && (
-          <div
-            className="text-xs text-gray-500"
-            dangerouslySetInnerHTML={{ __html: footerRightContent }}
-          />
+          <div dangerouslySetInnerHTML={{ __html: footerRightContent }} />
         )}
       </div>
     </footer>

--- a/app/footer.tsx
+++ b/app/footer.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { getCommitHash } from "@/utils/git";
+
+export default function Footer() {
+  const commitHash = getCommitHash();
+  const footerRightContent = process.env.NEXT_PUBLIC_FOOTER_RIGHT_HTML;
+
+  return (
+    <footer className="sm:fixed bottom-0 left-0 right-0 bg-gray-50 border-t border-gray-200 py-2 z-20">
+      <div className="px-3 flex justify-between items-center">
+        <span className="text-xs text-gray-500">Version: {commitHash}</span>
+        {footerRightContent && (
+          <div
+            className="text-xs text-gray-500"
+            dangerouslySetInnerHTML={{ __html: footerRightContent }}
+          />
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Montserrat, Roboto } from "next/font/google";
 import "./globals.css";
 import NavBar from "./nav-bar";
+import Footer from "./footer";
 import { UserProvider } from "./context";
 import clsx from "clsx";
 import { CONSTS } from "@/utils/constants";
@@ -39,11 +40,12 @@ export default function RootLayout({
           <main
             className={clsx(
               "lg:px-24 sm:px-10 p-6",
-              CONSTS.MULTIPLE_EVENTS ? "py-24" : "pt-12 pb-24"
+              CONSTS.MULTIPLE_EVENTS ? "py-24 sm:pb-16" : "pt-12 pb-4 sm:pb-16"
             )}
           >
             {children}
           </main>
+          <Footer />
         </UserProvider>
       </body>
     </html>

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,33 @@
+const { execSync } = require('child_process');
+
+function getCommitHash() {
+  try {
+    // Get the short commit hash
+    const hash = execSync('git rev-parse --short HEAD', { 
+      encoding: 'utf-8',
+      cwd: process.cwd()
+    }).trim();
+
+    // Check if there are uncommitted changes
+    let isDirty = false;
+    try {
+      const status = execSync('git status --porcelain', { 
+        encoding: 'utf-8',
+        cwd: process.cwd()
+      }).trim();
+      isDirty = status.length > 0;
+    } catch {
+      // If git status fails, assume not dirty
+      isDirty = false;
+    }
+
+    return isDirty ? `${hash}-dirty` : hash;
+  } catch (error) {
+    // If git is not available or not a git repo, return unknown
+    return 'unknown';
+  }
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
@@ -10,6 +40,11 @@ const nextConfig = {
   },
   eslint: {
     dirs: ["app", "db", "utils"],
+  },
+  env: {
+    NEXT_PUBLIC_COMMIT_HASH: process.env.VERCEL_GIT_COMMIT_SHA 
+      ? process.env.VERCEL_GIT_COMMIT_SHA.substring(0, 7) // Shorten Vercel's full hash
+      : getCommitHash(),
   },
 };
 

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -1,0 +1,5 @@
+// This function is safe to use on the client side
+export function getCommitHash(): string {
+  // On the client, we can only use the environment variable that was set at build time
+  return process.env.NEXT_PUBLIC_COMMIT_HASH || "unknown";
+}


### PR DESCRIPTION
The footer is fixed on desktop but only at the very end on mobile to save screen space.

Also add some documentation for environment variables in general.